### PR TITLE
Fix repo URL: vmware -> vmware-tanzu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - ./shellcheck-on-linux-only.sh
   - asdf plugin-add $TOOL_NAME ./
   - asdf list-all $TOOL_NAME
-  - asdf plugin-test $TOOL_NAME ./ "$TOOL_TEST_COMMAND" --asdf-tool-version $TOOL_VERSION
+  - asdf plugin test $TOOL_NAME ./ --asdf-plugin-gitref "$TRAVIS_COMMIT" --asdf-tool-version $TOOL_VERSION "$TOOL_TEST_COMMAND"
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - ./shellcheck-on-linux-only.sh
   - asdf plugin-add $TOOL_NAME ./
   - asdf list-all $TOOL_NAME
-  - asdf plugin test $TOOL_NAME ./ --asdf-plugin-gitref "$TRAVIS_COMMIT" --asdf-tool-version $TOOL_VERSION "$TOOL_TEST_COMMAND"
+  - asdf plugin-test $TOOL_NAME "$TRAVIS_BUILD_DIR" --asdf-plugin-gitref "$TRAVIS_COMMIT" --asdf-tool-version $TOOL_VERSION "$TOOL_TEST_COMMAND"
 os:
   - linux
   - osx

--- a/bin/install
+++ b/bin/install
@@ -73,7 +73,7 @@ get_download_url() {
   local filename
   filename="$(get_filename "$version" "$platform" "$binary_name")"
 
-  echo "https://github.com/vmware/octant/releases/download/v${version}/${filename}"
+  echo "https://github.com/vmware-tanzu/octant/releases/download/v${version}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # https://github.com/vmware/octant/releases/download/v0.6.0/octant_0.6.0_Linux-64bit.tar.gz
-github_coordinates=vmware/octant
+github_coordinates=vmware-tanzu/octant
 releases_path="https://api.github.com/repos/${github_coordinates}/releases"
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then


### PR DESCRIPTION
@looztra -- I noticed today that VMWare had moved the Ocant repository to a new user/org. This broke the `asdf` plugin!

Fixing was easy. And, of course, thanks for sharing your plugin!